### PR TITLE
Add support for Home and End keys

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -9,6 +9,8 @@ export interface RovingFocusContextValue {
   unregisterElement: (element: FocusableElement) => void;
   setFocusedElement: (element: FocusableElement) => void;
   focusNextElement: (direction: Direction) => void;
+  focusFirstElement: () => void;
+  focusLastElement: () => void;
 }
 
 export const RovingFocusContext = createContext<RovingFocusContextValue | null>(

--- a/src/use-roving-focus.ts
+++ b/src/use-roving-focus.ts
@@ -50,6 +50,12 @@ export const useRovingFocus = <T extends FocusableElement>({
         case 'ArrowDown':
           context.focusNextElement('down');
           break;
+        case 'Home':
+          context.focusFirstElement();
+          break;
+        case 'End':
+          context.focusLastElement();
+          break;
         default:
           return;
       }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,6 +86,24 @@ export function getFirstElement(
 }
 
 /**
+ * Returns the bottom-right element.
+ */
+export function getLastElement(
+  elements: ElementWithPosition[],
+): FocusableElement | null {
+  const sortedElements = elements.sort((a, b) => {
+    // Sort by right position if elements are on the same row.
+    if (arePositionsOverlapping(a.position, b.position, 'row')) {
+      return b.position.right - a.position.right;
+    }
+    // Otherwise sort by bottom position.
+    return b.position.bottom - a.position.bottom;
+  });
+
+  return sortedElements[0]?.element ?? null;
+}
+
+/**
  * Returns the distance between the closest edges of two element positions.
  */
 function getDistanceBetweenEdges(


### PR DESCRIPTION
Adds support for `Home` and `End` key presses, where `Home` moves focus to the first element (top-left) and `End` moves focus to the last element (bottom-right).

On Mac keyboards, use `fn` + `ArrowLeft` for `Home` and `fn` + `ArrowRight` for `End`.