### PR TITLE
Improve handling of disabled elements

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -214,8 +214,15 @@ export function getNextElement(
  * Determines whether an element is active (i.e. not disabled).
  */
 export function isElementActive(element: FocusableElement): boolean {
+  return !isElementDisabled(element);
+}
+
+/**
+ * Determines whether an element is disabled.
+ */
+export function isElementDisabled(element: FocusableElement): boolean {
   return (
-    element.getAttribute('disabled') !== 'true' &&
-    element.getAttribute('aria-disabled') !== 'true'
+    ('disabled' in element && element.disabled === true) ||
+    element.ariaDisabled === 'true'
   );
 }


### PR DESCRIPTION
Adds a `MutationObserver` to observe changes to the `disabled` and `aria-disabled` attributes of registered elements.

Fixes an issue with the `isElementActive` logic.