### PR TITLE
Add RTL support

### DIFF
--- a/.changeset/rude-turkeys-wash.md
+++ b/.changeset/rude-turkeys-wash.md
@@ -1,0 +1,5 @@
+---
+'react-roving-focus': minor
+---
+
+Add support for right-to-left layouts

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Flexible roving focus (aka [roving tabindex](https://www.w3.org/WAI/ARIA/apg/pra
 
 ## Examples
 
-Refer to the [Storybook](https://jasongerbes.github.io/react-roving-focus) for various layout examples:
+Refer to the [Storybook](https://jasongerbes.github.io/react-roving-focus) for various examples:
 
 - [Horizontal layout](https://jasongerbes.github.io/react-roving-focus/?path=/story/examples-horizontal-layout--basic)
 - [Vertical layout](https://jasongerbes.github.io/react-roving-focus/?path=/story/examples-vertical-layout--basic)
@@ -14,6 +14,7 @@ Refer to the [Storybook](https://jasongerbes.github.io/react-roving-focus) for v
 - [Responsive grid layout](https://jasongerbes.github.io/react-roving-focus/?path=/story/examples-grid-layout--responsive-columns)
 - [Nested grid layout](https://jasongerbes.github.io/react-roving-focus/?path=/story/examples-nested-grid-layout--basic)
 - [Masonry layout](https://jasongerbes.github.io/react-roving-focus/?path=/story/examples-masonry-layout--basic) (aka modular grid)
+- [Right-to-left layout](https://jasongerbes.github.io/react-roving-focus/?path=/story/examples-grid-layout--rtl)
 
 ## How it works
 
@@ -61,7 +62,7 @@ Wrap a group of focusable elements in a `<RovingFocusGroup>` and use the `useRov
 ```tsx
 import { RovingFocusGroup, useRovingFocus } from 'react-roving-focus';
 
-function ExampleGroup() {
+function Example() {
   return (
     <RovingFocusGroup>
       <div>
@@ -136,6 +137,48 @@ function ExampleItem({ children }: { children: React.ReactNode }) {
     <button ref={ref} tabIndex={tabIndex}>
       {children}
     </button>
+  );
+}
+```
+
+### With right-to-left layouts
+
+To support right-to-left layouts, set `dir="rtl"` on the root HTML element.
+
+```tsx
+import { RovingFocusGroup } from 'react-roving-focus';
+
+function App() {
+  return (
+    <html dir="rtl">
+      <body>
+        <RovingFocusGroup>
+          <div>
+            <ExampleItem>1</ExampleItem>
+            <ExampleItem>2</ExampleItem>
+            <ExampleItem>3</ExampleItem>
+          </div>
+        </RovingFocusGroup>
+      </body>
+    </html>
+  );
+}
+```
+
+Alternatively, set `dir="rtl"` on the `<RovingFocusGroup>`:
+
+```tsx
+import { RovingFocusGroup } from 'react-roving-focus';
+
+function Example() {
+  return (
+    <RovingFocusGroup dir="rtl">
+      <div>
+        <ExampleItem>1</ExampleItem>
+        <ExampleItem>2</ExampleItem>
+        <ExampleItem>3</ExampleItem>
+      </div>
+    </RovingFocusGroup>
   );
 }
 ```

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,9 @@
 import { createContext, useContext } from 'react';
-import type { Direction, ElementCallbacks, FocusableElement } from './types.js';
+import type {
+  MoveDirection,
+  ElementCallbacks,
+  FocusableElement,
+} from './types.js';
 
 export interface RovingFocusContextValue {
   registerElement: (
@@ -8,7 +12,7 @@ export interface RovingFocusContextValue {
   ) => void;
   unregisterElement: (element: FocusableElement) => void;
   setFocusedElement: (element: FocusableElement) => void;
-  focusNextElement: (direction: Direction) => void;
+  focusNextElement: (direction: MoveDirection) => void;
   focusFirstElement: () => void;
   focusLastElement: () => void;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,4 +7,4 @@ export {
   RovingFocusGroup,
   type RovingFocusGroupProps,
 } from './roving-focus-group.jsx';
-export { type FocusableElement } from './types.js';
+export { type FocusableElement, type TextDirection } from './types.js';

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,6 +18,7 @@ export interface ElementCallbacks {
   onTabIndexChange: (tabIndex: TabIndex) => void;
 }
 
-export type Direction = 'left' | 'right' | 'up' | 'down';
+export type TextDirection = 'rtl' | 'ltr';
+export type MoveDirection = 'left' | 'right' | 'up' | 'down';
 export type Axis = 'row' | 'column';
 export type TabIndex = -1 | 0;

--- a/src/use-text-direction.ts
+++ b/src/use-text-direction.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react';
+import { TextDirection } from './types';
+
+/**
+ * Returns the text direction of the document.
+ * @param dir - The text direction to use. If not provided, it will be detected from the document.
+ * @returns The text direction of the document.
+ */
+export function useTextDirection(dir?: TextDirection): TextDirection {
+  const [direction, setDirection] = useState<TextDirection>(getTextDirection());
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => {
+      const newDirection = getTextDirection();
+      setDirection(newDirection);
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['dir'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return dir ?? direction;
+}
+
+function getTextDirection(): TextDirection {
+  const dir = document.dir.toLowerCase();
+
+  if (dir === 'rtl') {
+    return 'rtl';
+  }
+
+  return 'ltr';
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,10 @@
 import type {
   Axis,
-  Direction,
+  MoveDirection,
   ElementPosition,
   ElementWithPosition,
   FocusableElement,
+  TextDirection,
 } from './types.js';
 
 /**
@@ -53,7 +54,7 @@ function arePositionsOverlapping(
 function isPositionInDirection(
   target: ElementPosition,
   current: ElementPosition,
-  direction: Direction,
+  direction: MoveDirection,
 ): boolean {
   switch (direction) {
     case 'left':
@@ -68,15 +69,21 @@ function isPositionInDirection(
 }
 
 /**
- * Returns the top-left element.
+ * Returns the first element based on the text direction.
+ *
+ * - 'ltr': The first element is the top left element.
+ * - 'rtl': The first element is the top right element.
  */
 export function getFirstElement(
   elements: ElementWithPosition[],
+  textDirection: TextDirection,
 ): FocusableElement | null {
   const sortedElements = elements.sort((a, b) => {
-    // Sort by left position if elements are on the same row.
+    // Sort by left/right position if elements are on the same row.
     if (arePositionsOverlapping(a.position, b.position, 'row')) {
-      return a.position.left - b.position.left;
+      return textDirection === 'ltr'
+        ? a.position.left - b.position.left
+        : b.position.right - a.position.right;
     }
     // Otherwise sort by top position.
     return a.position.top - b.position.top;
@@ -86,15 +93,21 @@ export function getFirstElement(
 }
 
 /**
- * Returns the bottom-right element.
+ * Returns the last element based on the text direction.
+ *
+ * - 'ltr': The last element is the bottom right element.
+ * - 'rtl': The last element is the bottom left element.
  */
 export function getLastElement(
   elements: ElementWithPosition[],
+  textDirection: TextDirection,
 ): FocusableElement | null {
   const sortedElements = elements.sort((a, b) => {
-    // Sort by right position if elements are on the same row.
+    // Sort by left/right position if elements are on the same row.
     if (arePositionsOverlapping(a.position, b.position, 'row')) {
-      return b.position.right - a.position.right;
+      return textDirection === 'ltr'
+        ? b.position.right - a.position.right
+        : a.position.left - b.position.left;
     }
     // Otherwise sort by bottom position.
     return b.position.bottom - a.position.bottom;
@@ -170,7 +183,7 @@ function getNearestElement(
 /**
  * Returns the axis for a given direction.
  */
-function getAxisForDirection(direction: Direction): Axis {
+function getAxisForDirection(direction: MoveDirection): Axis {
   return direction === 'left' || direction === 'right' ? 'row' : 'column';
 }
 
@@ -179,7 +192,7 @@ function getAxisForDirection(direction: Direction): Axis {
  */
 export function getNextElement(
   currentElement: FocusableElement,
-  direction: Direction,
+  direction: MoveDirection,
   elements: ElementWithPosition[],
 ): FocusableElement | null {
   const currentPosition = getElementPosition(currentElement);

--- a/stories/grid-layout.stories.tsx
+++ b/stories/grid-layout.stories.tsx
@@ -17,6 +17,15 @@ export const FixedColumns: Story = {
   },
 };
 
+export const RTL: Story = {
+  name: 'Right-to-Left',
+  args: {
+    itemCount: 12,
+    columnCount: 'fixed',
+    dir: 'rtl',
+  },
+};
+
 export const ResponsiveColumns: Story = {
   args: {
     itemCount: 50,

--- a/stories/grid-layout.tsx
+++ b/stories/grid-layout.tsx
@@ -1,4 +1,4 @@
-import { RovingFocusGroup } from '../src';
+import { RovingFocusGroup, TextDirection } from '../src';
 import { FocusableItem } from './focusable-item';
 import { LayoutContainer } from './layout-container';
 import { cn } from './utils';
@@ -6,16 +6,18 @@ import { cn } from './utils';
 export interface GridLayoutProps {
   itemCount: number;
   columnCount: 'fixed' | 'responsive';
+  dir?: TextDirection;
   disabledItems?: number[];
 }
 
 export function GridLayout({
   itemCount,
   columnCount,
+  dir,
   disabledItems,
 }: GridLayoutProps) {
   return (
-    <RovingFocusGroup>
+    <RovingFocusGroup dir={dir}>
       <LayoutContainer
         className={cn(
           'grid',
@@ -23,6 +25,7 @@ export function GridLayout({
           columnCount === 'responsive' &&
             'grid-cols-[repeat(auto-fill,_minmax(120px,_1fr))]',
         )}
+        dir={dir}
       >
         {Array.from({ length: itemCount }, (_, i) => (
           <FocusableItem key={i} disabled={disabledItems?.includes(i + 1)}>

--- a/stories/horizontal-layout.stories.tsx
+++ b/stories/horizontal-layout.stories.tsx
@@ -17,6 +17,15 @@ export const Basic: Story = {
   },
 };
 
+export const RTL: Story = {
+  name: 'Right-to-Left',
+  args: {
+    itemCount: 5,
+    overflow: 'none',
+    dir: 'rtl',
+  },
+};
+
 export const Scrollable: Story = {
   args: {
     itemCount: 50,

--- a/stories/horizontal-layout.tsx
+++ b/stories/horizontal-layout.tsx
@@ -1,4 +1,4 @@
-import { RovingFocusGroup } from '../src';
+import { RovingFocusGroup, TextDirection } from '../src';
 import { FocusableItem } from './focusable-item';
 import { LayoutContainer } from './layout-container';
 import { cn } from './utils';
@@ -6,22 +6,25 @@ import { cn } from './utils';
 export interface HorizontalLayoutProps {
   itemCount: number;
   overflow: 'scroll' | 'wrap' | 'none';
+  dir?: TextDirection;
   disabledItems?: number[];
 }
 
 export function HorizontalLayout({
   itemCount,
   overflow,
+  dir,
   disabledItems,
 }: HorizontalLayoutProps) {
   return (
-    <RovingFocusGroup>
+    <RovingFocusGroup dir={dir}>
       <LayoutContainer
         className={cn(
           'flex',
           overflow === 'wrap' && 'flex-wrap',
           overflow === 'scroll' && 'overflow-x-scroll',
         )}
+        dir={dir}
       >
         {Array.from({ length: itemCount }, (_, i) => (
           <FocusableItem

--- a/stories/layout-container.tsx
+++ b/stories/layout-container.tsx
@@ -1,27 +1,33 @@
+import { TextDirection } from '../src';
 import { cn } from './utils';
 
 export interface LayoutContainerProps {
-  children: React.ReactNode;
   className?: string;
+  children: React.ReactNode;
+  dir?: TextDirection;
 }
 
-export function LayoutContainer({ children, className }: LayoutContainerProps) {
+export function LayoutContainer({
+  className,
+  children,
+  dir,
+}: LayoutContainerProps) {
   return (
-    <>
+    <div className="flex flex-col items-start gap-2.5" dir={dir}>
       <button
-        className="mb-2.5 rounded-sm px-1 text-center text-sm text-balance text-gray-500 outline-amber-400 focus:outline-2"
+        className="rounded-sm px-1 text-center text-sm text-balance text-gray-500 outline-amber-400 focus:outline-2"
         tabIndex={0}
       >
         Click here, press <code>TAB</code>, then use <code>ARROW KEYS</code>
       </button>
       <div
         className={cn(
-          'gap-2.5 rounded-2xl border border-gray-300 bg-gray-50 p-3',
+          'w-full gap-2.5 rounded-2xl border border-gray-300 bg-gray-50 p-3',
           className,
         )}
       >
         {children}
       </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
Adds support for right-to-left layouts by updating the first/last element logic.

Uses the root HTML `dir` attribute to determine text direction by default.

Can be overridden via `<RovingFocusGroup dir="rtl">`.


